### PR TITLE
[DS-728] export model upon training

### DIFF
--- a/aocr/__main__.py
+++ b/aocr/__main__.py
@@ -39,11 +39,6 @@ def process_args(args, defaults):
                                help=('export format'
                                      ' (default: %s)'
                                      % (defaults.EXPORT_FORMAT)))
-    parser_base.add_argument('--export-path', dest='export_path', metavar='dir',
-                               type=str, default=defaults.EXPORT_PATH,
-                               help=('Directory to save the exported model to,'
-                                     'default=%s'
-                                     % (defaults.EXPORT_PATH)))
 
     # Dataset generation
     parser_dataset = subparsers.add_parser('dataset', parents=[parser_base],
@@ -192,7 +187,11 @@ def process_args(args, defaults):
     parser_export = subparsers.add_parser('export', parents=[parser_base, parser_model],
                                           help='Export the model with weights for production use.')
     parser_export.set_defaults(phase='export', steps_per_checkpoint=0, batch_size=1)
-
+    parser_export.add_argument('export_path', nargs='?', metavar='dir',
+                               type=str, default=defaults.EXPORT_PATH,
+                               help=('Directory to save the exported model to,'
+                                     'default=%s'
+                                     % (defaults.EXPORT_PATH)))
     # Predicting
     parser_predict = subparsers.add_parser('predict', parents=[parser_base, parser_model],
                                            help='Predict text from files (feed through stdin).')

--- a/aocr/__main__.py
+++ b/aocr/__main__.py
@@ -266,7 +266,8 @@ def main(args=None):
       
             if not parameters.save_checkpoints_only:
                 exporter = Exporter(model)
-                exporter.save(parameters.export_path, parameters.format)
+                exported_dir = f'{parameters.model_dir}/exported_model'
+                exporter.save(exported_dir, parameters.format)
                 return
       
         elif parameters.phase == 'test':

--- a/aocr/__main__.py
+++ b/aocr/__main__.py
@@ -167,7 +167,7 @@ def process_args(args, defaults):
     parser_train.add_argument('--no-resume', dest='load_model', action='store_false',
                               help=('create a new model even if checkpoints already exist'))
     parser_train.add_argument('--save-checkpoints-only', dest='save_checkpoints_only', action='store_true',
-                              help=('do not generate saved_model.pb file upon training end'))
+                              help=('do not export model to saved_model/frozengraph format after training finishes'))
                 
     # Testing
     parser_test = subparsers.add_parser('test', parents=[parser_base, parser_model],

--- a/aocr/defaults.py
+++ b/aocr/defaults.py
@@ -23,6 +23,7 @@ class Config(object):
     FORCE_UPPERCASE = True
     SAVE_FILENAME = False
     FULL_ASCII = False
+    SAVE_CHECKPOINTS_ONLY = False
 
     # Optimization
     NUM_EPOCH = 1000


### PR DESCRIPTION
Tiny change which (additionally to generating checkpoints) exports the trained model to saved_model.pb/frozengraph format after training is done. The exported model will be placed with the checkpoints directory. This will be the new default unless disabled using the `--save-checkpoints-only` flag. 